### PR TITLE
Support for wrapping bindata, generated with github.com/go-bindata/go-bindata

### DIFF
--- a/pkg/xlate/doc.go
+++ b/pkg/xlate/doc.go
@@ -1,7 +1,10 @@
 // Package xlate translates strings from one language to another, using data
 // injected via the Setup function. The injected data is a map, as generated
-// by go-bindata. Map keys are asset names, such as en-us.json, while values
-// are func()([]byte,error). The []byte is json from cmd/xtract.
+// by go-bindata. We support two binary data generators:
+// - github.com/jteeuwen/go-bindata (archived, not supported any more)
+// - github.com/go-bindata/go-bindata.
+// In either case, map keys are asset names, such as en-us.json, while values
+// are asset access functions. The asset value (payload) is json from cmd/xtract.
 //
 // This package assumes there are no duplicate strings in the primary language.
 // If two strings are the same in the primary language but differ in another,

--- a/pkg/xlate/xlate_test.go
+++ b/pkg/xlate/xlate_test.go
@@ -3,6 +3,7 @@ package xlate
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,6 +50,7 @@ func TestTranslations(t *testing.T) {
 	out = T(unxlated)
 	require.Equal(t, unxlated, out, "no translation - must pass through verbatim")
 }
+
 func TestMissingLang(t *testing.T) {
 	bd := Bindata{
 		"te-st.json": func() ([]byte, error) { return []byte(tsjson), nil },
@@ -62,4 +64,34 @@ func TestMissingLang(t *testing.T) {
 	require.Error(t, err, "expect error for missing language")
 	out := T(Str)
 	require.Equal(t, out, Str, "no translation - must pass through verbatim")
+}
+
+func TestAdoptBindata(t *testing.T) {
+	type someAsset struct {
+		d []byte
+		o string
+	}
+	type someBindata map[string]func() (*someAsset, error)
+	bdIn := someBindata{
+		"a": func() (*someAsset, error) {
+			return &someAsset{[]byte("aa"), "bb"}, nil
+		},
+		"b": func() (*someAsset, error) {
+			return &someAsset{[]byte("bb"), "bb"}, nil
+		},
+	}
+	bdOut, err := AdoptBindata(bdIn)
+	require.NotNil(t, bdOut)
+	require.Nil(t, err)
+	assert.Equal(t, 2, len(bdOut))
+	{
+		a, e := bdOut["a"]()
+		assert.Nil(t, e)
+		assert.Equal(t, []byte("aa"), a)
+	}
+	{
+		a, e := bdOut["b"]()
+		assert.Nil(t, e)
+		assert.Equal(t, []byte("bb"), a)
+	}
 }


### PR DESCRIPTION
The github.com/jteeuwen/go-bindata generator (xlate originally relies on) is no longer supported (repo is archived by the owner). 